### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/Vyrent/CRM.png?label=ready&title=Ready)](https://waffle.io/Vyrent/CRM)
 [![dependencies](https://david-dm.org/vyrent/crm.png)](https://david-dm.org/vyrent/crm)
 [![Build Status](https://travis-ci.org/Vyrent/CRM.svg?branch=master)](https://travis-ci.org/Vyrent/CRM)
 [![Coverage Status](https://coveralls.io/repos/github/Vyrent/CRM/badge.svg?branch=master)](https://coveralls.io/github/Vyrent/CRM?branch=master)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/Vyrent/CRM

This was requested by a real person (user amirsabersharifi) on waffle.io, we're not trying to spam you.